### PR TITLE
Allow arrays in alias_action

### DIFF
--- a/lib/cancan/ability/actions.rb
+++ b/lib/cancan/ability/actions.rb
@@ -33,6 +33,7 @@ module CanCan
       #
       # This way one can use params[:action] in the controller to determine the permission.
       def alias_action(*args)
+        args.flatten!
         target = args.pop[:to]
         validate_target(target)
         aliased_actions[target] ||= []


### PR DESCRIPTION
Allows for specifying an array `[ ]` within your alias_action.  

Usage
`alias_action [:read, :create], :to :crud`

Versus
`alias_action :read, :create, :to :crud`